### PR TITLE
Allow adding additional volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $ docker-machine create \
 - `--cloudscale-anti-affinity-with`: the UUID of another server to create an anti-affinity group with that server or add it to the same group as that server.
 - `--cloudscale-userdata`: string containing cloud-init user data
 - `--cloudscale-userdatafile`: path to file with cloud-init user data
+- `--cloudscale-volumes`: string containing [volume](https://www.cloudscale.ch/en/api/v1#volumes) in json format
 
 
 

--- a/driver.go
+++ b/driver.go
@@ -230,18 +230,35 @@ func (d *Driver) Create() error {
 
 	client := d.getClient()
 
-	createRequest := &cloudscale.ServerRequest{
-		Image:             d.Image,
-		Flavor:            d.Flavor,
-		Name:              d.MachineName,
-		UsePublicNetwork:  &d.UsePublicNetwork,
-		UsePrivateNetwork: &d.UsePrivateNetwork,
-		UseIPV6:           &d.UseIPV6,
-		UserData:          userdata,
-		SSHKeys:           []string{string(publicKey)},
-		VolumeSizeGB:      d.VolumeSizeGB,
-		AntiAffinityWith:  d.AntiAffinityWith,
-		ServerGroups:      d.ServerGroups,
+	var createRequest *cloudscale.ServerRequest
+
+	if len(volumes) > 0 {
+		createRequest = &cloudscale.ServerRequest{
+			Image:             d.Image,
+			Flavor:            d.Flavor,
+			Name:              d.MachineName,
+			UsePrivateNetwork: &d.UsePrivateNetwork,
+			UseIPV6:           &d.UseIPV6,
+			UserData:          userdata,
+			SSHKeys:           []string{string(publicKey)},
+			VolumeSizeGB:      d.VolumeSizeGB,
+			AntiAffinityWith:  d.AntiAffinityWith,
+			ServerGroups:      d.ServerGroups,
+			Volumes:           &volumes,
+		}
+	} else {
+		createRequest = &cloudscale.ServerRequest{
+			Image:             d.Image,
+			Flavor:            d.Flavor,
+			Name:              d.MachineName,
+			UsePrivateNetwork: &d.UsePrivateNetwork,
+			UseIPV6:           &d.UseIPV6,
+			UserData:          userdata,
+			SSHKeys:           []string{string(publicKey)},
+			VolumeSizeGB:      d.VolumeSizeGB,
+			AntiAffinityWith:  d.AntiAffinityWith,
+			ServerGroups:      d.ServerGroups,
+		}
 	}
 
 	newServer, err := client.Servers.Create(context.TODO(), createRequest)

--- a/driver.go
+++ b/driver.go
@@ -223,18 +223,35 @@ func (d *Driver) Create() error {
 
 	client := d.getClient()
 
-	createRequest := &cloudscale.ServerRequest{
-		Image:             d.Image,
-		Flavor:            d.Flavor,
-		Name:              d.MachineName,
-		UsePrivateNetwork: &d.UsePrivateNetwork,
-		UseIPV6:           &d.UseIPV6,
-		UserData:          userdata,
-		SSHKeys:           []string{string(publicKey)},
-		VolumeSizeGB:      d.VolumeSizeGB,
-		AntiAffinityWith:  d.AntiAffinityWith,
-		ServerGroups:      d.ServerGroups,
-		Volumes:           &volumes,
+	var createRequest *cloudscale.ServerRequest
+
+	if len(volumes) > 0 {
+		createRequest = &cloudscale.ServerRequest{
+			Image:             d.Image,
+			Flavor:            d.Flavor,
+			Name:              d.MachineName,
+			UsePrivateNetwork: &d.UsePrivateNetwork,
+			UseIPV6:           &d.UseIPV6,
+			UserData:          userdata,
+			SSHKeys:           []string{string(publicKey)},
+			VolumeSizeGB:      d.VolumeSizeGB,
+			AntiAffinityWith:  d.AntiAffinityWith,
+			ServerGroups:      d.ServerGroups,
+			Volumes:           &volumes,
+		}
+	} else {
+		createRequest = &cloudscale.ServerRequest{
+			Image:             d.Image,
+			Flavor:            d.Flavor,
+			Name:              d.MachineName,
+			UsePrivateNetwork: &d.UsePrivateNetwork,
+			UseIPV6:           &d.UseIPV6,
+			UserData:          userdata,
+			SSHKeys:           []string{string(publicKey)},
+			VolumeSizeGB:      d.VolumeSizeGB,
+			AntiAffinityWith:  d.AntiAffinityWith,
+			ServerGroups:      d.ServerGroups,
+		}
 	}
 
 	newServer, err := client.Servers.Create(context.TODO(), createRequest)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
-	github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20190523132001-c0ff9b92e8ad
+	github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20191015091802-894d6d497c88
 	github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4
 	github.com/docker/machine v0.16.1
 	github.com/golang/protobuf v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,9 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20190523132001-c0ff9b92e8ad h1:pPMRZKYqnwvoucO63TaNIdTc6hRea+3nVRCBykxZ8lw=
 github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20190523132001-c0ff9b92e8ad/go.mod h1:FhOTOCgKAVvRRMQc1mC0D7xK/3zYnmcZBWFXNkacvMc=
+github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20191015091802-894d6d497c88 h1:gOUcZvveD2Cue4L/C128/oBkL+66odoNY6ug3yH4kgg=
+github.com/cloudscale-ch/cloudscale-go-sdk v0.0.0-20191015091802-894d6d497c88/go.mod h1:FhOTOCgKAVvRRMQc1mC0D7xK/3zYnmcZBWFXNkacvMc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4 h1:u7P9ul4ElF92ZjxTwdWBgrXAMWXCLLfgceq4hdAMcE4=
 github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -11,8 +14,10 @@ github.com/docker/machine v0.16.1/go.mod h1:I8mPNDeK1uH+JTcUU7X0ZW8KiYz0jyAgNaeS
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e h1:IzypfodbhbnViNUO/MEh0FzCUooG97cIGfdggUrUSyU=


### PR DESCRIPTION
Allows to add additional volumes to the cloudscale.ch vm.

Example:

`docker-machine create --driver cloudscale --cloudscale-image ubuntu-18.04 --cloudscale-ssh-user ubuntu --cloudscale-flavor flex-2 --cloudscale-volumes "{\"name\": \"morestorage\", \"type\": \"ssd\", \"size_gb\": 1}" spl-test`